### PR TITLE
update for QuoVadis issued certificate

### DIFF
--- a/cambridge
+++ b/cambridge
@@ -1,5 +1,5 @@
 Description='eduroam'
-Interface=wlan0
+Interface=INTERFACE_NAME
 Connection=wireless
 Security=wpa-configsection
 IP=dhcp
@@ -18,8 +18,8 @@ WPAConfigSection=(
     'identity="EDUROAM_IDENTIFIER"'
     'anonymous_identity="@cam.ac.uk"'
     'password="NETWORK_ACCESS_TOKEN"'
-    'ca_cert="/usr/share/ca-certificates/trust-source/mozilla.trust.crt"'
-    'subject_match="/C=GB/ST=England/L=Cambridge/O=University of Cambridge/OU=Computing Service/CN=network.tokens.csx.cam.ac.uk"'
+    'ca_cert="/etc/ssl/certs/QuoVadis_Root_CA_2.pem"'
+    'subject_match="/C=GB/ST=Cambridgeshire/L=CAMBRIDGE/O=University of Cambridge/OU=University Information Services/CN=network.tokens.csx.cam.ac.uk"'
     'phase1="peaplabel=0"'
     'phase2="auth=MSCHAPv2"'
 )


### PR DESCRIPTION
This update changes the configuration file so that it:
1. has a placeholder in all caps instead of wlan0 for the interface
    name, letting users know that they need to supply it;
2. uses the QuoVadis Root CA certificate instead of the Mozilla one;
3. changes the certificate subject matching string so it matches 2.
